### PR TITLE
Add caption manager and listener integration

### DIFF
--- a/app/src/main/java/com/example/captions/CaptionManager.kt
+++ b/app/src/main/java/com/example/captions/CaptionManager.kt
@@ -1,0 +1,46 @@
+package com.example.captions
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Coordinates caption updates between UI and persistent storage.
+ *
+ * @param uiUpdater invoked with every partial result to update the live captions
+ * @param storage invoked with each final result to be persisted by a background job
+ */
+class CaptionManager(
+    private val uiUpdater: (String) -> Unit,
+    private val storage: (String) -> Unit
+) {
+    private val pendingFinal = ConcurrentLinkedQueue<String>()
+
+    /**
+     * Called when a partial transcription is available. The partial text
+     * is forwarded directly to the UI updater for live captioning.
+     */
+    fun onPartial(text: String) {
+        uiUpdater(text)
+    }
+
+    /**
+     * Called when a final transcription is produced. The text is queued
+     * for persistence and forwarded to the provided storage callback.
+     */
+    fun onFinal(text: String) {
+        pendingFinal.add(text)
+        storage(text)
+    }
+
+    /**
+     * Exposes any queued final captions. Useful for testing or when the
+     * storage job wants to drain items manually.
+     */
+    fun drainFinal(): List<String> {
+        val result = mutableListOf<String>()
+        while (true) {
+            val next = pendingFinal.poll() ?: break
+            result.add(next)
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/example/listeners/WearMessageListener.kt
+++ b/app/src/main/java/com/example/listeners/WearMessageListener.kt
@@ -1,0 +1,22 @@
+package com.example.listeners
+
+import com.example.captions.CaptionManager
+import com.example.session.AsrSession
+
+/**
+ * Listens for messages coming from the wearable device and forwards
+ * transcription updates to the [CaptionManager].
+ */
+class WearMessageListener(
+    private val session: AsrSession,
+    private val captions: CaptionManager
+) {
+    /**
+     * Call whenever new data has arrived for this session. Any available
+     * partial or final results will be forwarded to the caption manager.
+     */
+    fun handleMessage() {
+        session.getPartial()?.let { captions.onPartial(it) }
+        session.getFinal()?.let { captions.onFinal(it) }
+    }
+}

--- a/app/src/main/java/com/example/session/AsrSession.kt
+++ b/app/src/main/java/com/example/session/AsrSession.kt
@@ -1,0 +1,24 @@
+package com.example.session
+
+/**
+ * Minimal representation of an ASR session. In a real implementation
+ * this would interface with the speech recognition service.
+ */
+class AsrSession {
+    private var partial: String? = null
+    private var final: String? = null
+
+    fun updatePartial(text: String) {
+        partial = text
+    }
+
+    fun updateFinal(text: String) {
+        final = text
+    }
+
+    /** Returns the latest partial transcription, if any. */
+    fun getPartial(): String? = partial
+
+    /** Returns the final transcription, if available. */
+    fun getFinal(): String? = final
+}


### PR DESCRIPTION
## Summary
- add CaptionManager to forward partial captions to UI and queue final captions for storage
- update WearMessageListener to send ASR session partial/final outputs to CaptionManager
- include simple AsrSession stub for completeness

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c8a8938832aaa8c1673226205da