### PR TITLE
Add jitter buffer for audio packet handling

### DIFF
--- a/app/src/main/java/com/example/ingest/JitterBuffer.kt
+++ b/app/src/main/java/com/example/ingest/JitterBuffer.kt
@@ -1,0 +1,28 @@
+package com.example.ingest
+
+import java.util.PriorityQueue
+
+/** Simple jitter buffer for audio packets. */
+class JitterBuffer(private val playoutDelayMs: Long = 50) {
+    data class AudioPacket(val timestampMs: Long, val data: ByteArray)
+
+    private val queue = PriorityQueue<AudioPacket>(compareBy { it.timestampMs })
+
+    /** Adds a packet to the buffer. */
+    fun add(packet: AudioPacket) {
+        queue.add(packet)
+    }
+
+    /**
+     * Returns the next frame if it is ready for playout based on the configured
+     * delay; otherwise returns null.
+     */
+    fun nextFrame(nowMs: Long = System.currentTimeMillis()): ByteArray? {
+        val packet = queue.peek() ?: return null
+        return if (packet.timestampMs + playoutDelayMs <= nowMs) {
+            queue.poll().data
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/listeners/WearMessageListener.kt
+++ b/app/src/main/java/com/example/listeners/WearMessageListener.kt
@@ -2,6 +2,8 @@ package com.example.listeners
 
 import com.example.captions.CaptionManager
 import com.example.session.AsrSession
+import com.example.ingest.JitterBuffer
+import com.example.ingest.JitterBuffer.AudioPacket
 
 /**
  * Listens for messages coming from the wearable device and forwards
@@ -9,13 +11,20 @@ import com.example.session.AsrSession
  */
 class WearMessageListener(
     private val session: AsrSession,
-    private val captions: CaptionManager
+    private val captions: CaptionManager,
+    private val buffer: JitterBuffer
 ) {
+    /** Feeds raw audio packets into the jitter buffer. */
+    fun onAudioPacket(packet: AudioPacket) {
+        buffer.add(packet)
+    }
+
     /**
-     * Call whenever new data has arrived for this session. Any available
-     * partial or final results will be forwarded to the caption manager.
+     * Call periodically to process buffered audio. Any resulting
+     * transcription updates will be forwarded to the caption manager.
      */
     fun handleMessage() {
+        buffer.nextFrame()?.let { session.receiveAudio(it) }
         session.getPartial()?.let { captions.onPartial(it) }
         session.getFinal()?.let { captions.onFinal(it) }
     }

--- a/app/src/main/java/com/example/session/AsrSession.kt
+++ b/app/src/main/java/com/example/session/AsrSession.kt
@@ -16,6 +16,11 @@ class AsrSession {
         final = text
     }
 
+    /** Accepts raw audio data for processing. */
+    fun receiveAudio(data: ByteArray) {
+        // Audio ingestion would occur here in a real implementation.
+    }
+
     /** Returns the latest partial transcription, if any. */
     fun getPartial(): String? = partial
 


### PR DESCRIPTION
## Summary
- add simple `JitterBuffer` for buffering audio packets
- let `WearMessageListener` route audio through the buffer and forward processed frames
- extend `AsrSession` with an audio ingestion entry point

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae116a1e64832aae260afb899af92f