### PR TITLE
Ensure final transcripts forwarded once

### DIFF
--- a/app/src/main/java/com/example/listeners/WearMessageListener.kt
+++ b/app/src/main/java/com/example/listeners/WearMessageListener.kt
@@ -22,7 +22,7 @@ class WearMessageListener(
 
     /** Stops the current recording session. */
     fun stopRecording() {
-        session?.getFinal()?.let { captions.onFinal(it) }
+        session?.consumeFinal()?.let { captions.onFinal(it) }
         session = null
     }
 
@@ -44,6 +44,6 @@ class WearMessageListener(
             s.getPartial()?.let { captions.onPartial(it) }
             frame = buffer.nextFrame()
         }
-        s.getFinal()?.let { captions.onFinal(it) }
+        s.consumeFinal()?.let { captions.onFinal(it) }
     }
 }

--- a/app/src/main/java/com/example/session/AsrSession.kt
+++ b/app/src/main/java/com/example/session/AsrSession.kt
@@ -31,4 +31,14 @@ class AsrSession {
 
     /** Returns the final transcription, if available. */
     fun getFinal(): String? = final
+
+    /**
+     * Returns the final transcription and clears it so the caller only
+     * receives each final result once.
+     */
+    fun consumeFinal(): String? {
+        val result = final
+        final = null
+        return result
+    }
 }


### PR DESCRIPTION
## Summary
- Add `consumeFinal` to `AsrSession` so final results are only processed once
- Use the new `consumeFinal` in `WearMessageListener` when forwarding transcripts to `CaptionManager`

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21bcda0c832ab1e2d2ae11308566