### PR TITLE
Add jitter buffer and native ASR session integration

### DIFF
--- a/app/src/main/java/com/example/session/AsrSession.kt
+++ b/app/src/main/java/com/example/session/AsrSession.kt
@@ -1,8 +1,8 @@
 package com.example.session
 
 /**
- * Minimal representation of an ASR session. In a real implementation
- * this would interface with the speech recognition service.
+ * Thin wrapper around the native ASR engine. Raw PCM audio is pushed into the
+ * engine and partial/final transcripts are retrieved via JNI bindings.
  */
 class AsrSession {
     companion object {
@@ -10,35 +10,37 @@ class AsrSession {
             System.loadLibrary("asr")
         }
     }
-    private var partial: String? = null
-    private var final: String? = null
 
-    fun updatePartial(text: String) {
-        partial = text
-    }
+    private var handle: Long = nativeCreate()
 
-    fun updateFinal(text: String) {
-        final = text
-    }
-
-    /** Accepts raw PCM audio data for processing. */
+    /** Feeds a chunk of 16-bit PCM audio to the recognizer. */
     fun pushPcm(data: ByteArray) {
-        // Audio ingestion would occur here in a real implementation.
+        nativePush(handle, data, data.size)
     }
 
     /** Returns the latest partial transcription, if any. */
-    fun getPartial(): String? = partial
+    fun getPartial(): String? = nativePartial(handle)
 
-    /** Returns the final transcription, if available. */
-    fun getFinal(): String? = final
+    /** Returns a finalized transcription segment, if available. */
+    fun consumeFinal(): String? = nativeFinal(handle)
 
-    /**
-     * Returns the final transcription and clears it so the caller only
-     * receives each final result once.
-     */
-    fun consumeFinal(): String? {
-        val result = final
-        final = null
-        return result
+    /** Releases the native resources backing this session. */
+    fun close() {
+        if (handle != 0L) {
+            nativeClose(handle)
+            handle = 0L
+        }
     }
+
+    @Suppress("deprecation")
+    protected fun finalize() {
+        close()
+    }
+
+    private external fun nativeCreate(): Long
+    private external fun nativePush(handle: Long, data: ByteArray, length: Int)
+    private external fun nativePartial(handle: Long): String?
+    private external fun nativeFinal(handle: Long): String?
+    private external fun nativeClose(handle: Long)
 }
+


### PR DESCRIPTION
## Summary
- Smooth wearable audio with built-in jitter buffer before decoding
- Wrap native ASR engine with JNI to emit partial and final transcripts
- Forward interim captions live and queue finalized text for storage

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `kotlinc app/src/main/java/com/example/ingest/JitterBuffer.kt app/src/main/java/com/example/listeners/WearMessageListener.kt app/src/main/java/com/example/session/AsrSession.kt app/src/main/java/com/example/captions/CaptionManager.kt -d /tmp/test.jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae299ee684832a952c78475722dc75