### PR TITLE
feat: add tile and microphone services

### DIFF
--- a/app-mobile/src/main/AndroidManifest.xml
+++ b/app-mobile/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+
+    <application>
+        <service
+            android:name=".service.PhoneMicService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+    </application>
+</manifest>

--- a/app-mobile/src/main/java/com/example/service/PhoneMicService.kt
+++ b/app-mobile/src/main/java/com/example/service/PhoneMicService.kt
@@ -1,0 +1,109 @@
+package com.example.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+/**
+ * Foreground service used on the phone to receive audio from the watch. The
+ * service exposes persistent mute and stop actions and is marked with the
+ * microphone foreground-service type for Android 14+ compliance.
+ */
+class PhoneMicService : Service() {
+    companion object {
+        const val ACTION_START = "com.example.service.action.START"
+        const val ACTION_STOP = "com.example.service.action.STOP"
+        const val ACTION_MUTE = "com.example.service.action.MUTE"
+
+        private const val CHANNEL_ID = "phone_mic"
+        private const val NOTIFICATION_ID = 1
+    }
+
+    private var muted = false
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            ACTION_MUTE -> {
+                muted = !muted
+                updateNotification()
+                return START_STICKY
+            }
+            else -> Unit
+        }
+
+        startForegroundService()
+        return START_STICKY
+    }
+
+    private fun startForegroundService() {
+        val notification = buildNotification()
+        if (Build.VERSION.SDK_INT >= 34) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun updateNotification() {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val muteIntent = PendingIntent.getService(
+            this,
+            0,
+            Intent(this, PhoneMicService::class.java).setAction(ACTION_MUTE),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val stopIntent = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, PhoneMicService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val text = if (muted) "Muted" else "Recording"
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Transcriber")
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setOngoing(true)
+            .addAction(0, if (muted) "Unmute" else "Mute", muteIntent)
+            .addAction(0, "Stop", stopIntent)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Microphone",
+            NotificationManager.IMPORTANCE_LOW
+        )
+        nm.createNotificationChannel(channel)
+    }
+
+    override fun onBind(intent: Intent?) = null
+}

--- a/app-wear/src/main/AndroidManifest.xml
+++ b/app-wear/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+
+    <application>
+        <service
+            android:name=".service.WearMicService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
+        <service
+            android:name=".ui.MicTileService"
+            android:exported="false"
+            android:permission="com.google.android.wearable.permission.BIND_TILE_PROVIDER">
+            <intent-filter>
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/app-wear/src/main/java/com/example/service/WearMicService.kt
+++ b/app-wear/src/main/java/com/example/service/WearMicService.kt
@@ -1,0 +1,123 @@
+package com.example.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.example.ui.MicTileService
+
+/**
+ * Service responsible for capturing audio from the watch microphone. The
+ * service runs in the foreground with a persistent notification that exposes
+ * mute and stop actions. The notification and foreground service type are
+ * configured to satisfy Android 14+ microphone requirements.
+ */
+class WearMicService : Service() {
+    companion object {
+        const val ACTION_START = "com.example.service.action.START"
+        const val ACTION_STOP = "com.example.service.action.STOP"
+        const val ACTION_MUTE = "com.example.service.action.MUTE"
+
+        private const val CHANNEL_ID = "wear_mic"
+        private const val NOTIFICATION_ID = 1
+
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+    }
+
+    private var muted = false
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            ACTION_MUTE -> {
+                muted = !muted
+                updateNotification()
+                return START_STICKY
+            }
+            else -> Unit
+        }
+
+        startForegroundService()
+        return START_STICKY
+    }
+
+    private fun startForegroundService() {
+        val notification = buildNotification()
+        isRunning = true
+        if (Build.VERSION.SDK_INT >= 34) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+        MicTileService.requestUpdate(this)
+    }
+
+    private fun updateNotification() {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val muteIntent = PendingIntent.getService(
+            this,
+            0,
+            Intent(this, WearMicService::class.java).setAction(ACTION_MUTE),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val stopIntent = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, WearMicService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val text = if (muted) "Muted" else "Recording"
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Transcriber")
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setOngoing(true)
+            .addAction(0, if (muted) "Unmute" else "Mute", muteIntent)
+            .addAction(0, "Stop", stopIntent)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Microphone",
+            NotificationManager.IMPORTANCE_LOW
+        )
+        nm.createNotificationChannel(channel)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        isRunning = false
+        MicTileService.requestUpdate(this)
+    }
+
+    override fun onBind(intent: Intent?) = null
+}

--- a/app-wear/src/main/java/com/example/ui/MicTileService.kt
+++ b/app-wear/src/main/java/com/example/ui/MicTileService.kt
@@ -1,0 +1,85 @@
+package com.example.ui
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.wear.tiles.ActionBuilders
+import androidx.wear.tiles.LayoutElementBuilders
+import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.tiles.RequestBuilders
+import androidx.wear.tiles.Tile
+import androidx.wear.tiles.TileBuilders
+import androidx.wear.tiles.TimelineBuilders
+import androidx.wear.tiles.TileService
+import com.example.service.WearMicService
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * Simple tile that toggles [WearMicService] on the watch. The tile displays a
+ * Start or Stop label depending on the running state of the service and sends
+ * the corresponding action when tapped.
+ */
+class MicTileService : TileService() {
+
+    override fun onTileRequest(requestParams: RequestBuilders.TileRequest): ListenableFuture<Tile> {
+        val running = WearMicService.isRunning
+        val label = if (running) "Stop" else "Start"
+        val action = if (running) WearMicService.ACTION_STOP else WearMicService.ACTION_START
+
+        val pi = PendingIntent.getService(
+            this,
+            0,
+            Intent(this, WearMicService::class.java).setAction(action),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val clickable = ModifiersBuilders.Clickable.Builder()
+            .setOnClick(ActionBuilders.AndroidPendingIntent.Builder(pi).build())
+            .build()
+
+        val text = LayoutElementBuilders.Text.Builder()
+            .setText(label)
+            .setFontStyle(LayoutElementBuilders.FontStyle.Builder().build())
+            .build()
+
+        val box = LayoutElementBuilders.Box.Builder()
+            .setModifiers(ModifiersBuilders.Modifiers.Builder().setClickable(clickable).build())
+            .addContent(text)
+            .build()
+
+        val layout = TileBuilders.Layout.Builder()
+            .setRoot(box)
+            .build()
+
+        val timeline = TimelineBuilders.Timeline.Builder()
+            .addTimelineEntry(
+                TimelineBuilders.TimelineEntry.Builder()
+                    .setLayout(layout)
+                    .build()
+            )
+            .build()
+
+        return Futures.immediateFuture(
+            TileBuilders.Tile.Builder()
+                .setResourcesVersion("1")
+                .setTimeline(timeline)
+                .build()
+        )
+    }
+
+    override fun onResourcesRequest(requestParams: RequestBuilders.ResourcesRequest): ListenableFuture<TileBuilders.Resources> {
+        return Futures.immediateFuture(
+            TileBuilders.Resources.Builder()
+                .setVersion("1")
+                .build()
+        )
+    }
+
+    companion object {
+        /** Requests an update for the tile so its state reflects the service. */
+        fun requestUpdate(context: Context) {
+            getUpdater(context).requestUpdate(MicTileService::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add WearMicService foreground service with microphone type and persistent notification
- add MicTileService to toggle WearMicService from a Wear OS tile
- add PhoneMicService with its own persistent microphone notification

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae341681ec832a95db415de39fa55d