### PR TITLE
Queue Opus packets and acknowledge delivery

### DIFF
--- a/app-wear/src/main/java/com/example/service/OpusPacketQueue.kt
+++ b/app-wear/src/main/java/com/example/service/OpusPacketQueue.kt
@@ -1,0 +1,50 @@
+package com.example.service
+
+/**
+ * Maintains a buffer of Opus packets and coordinates resend logic.
+ *
+ * Packets are enqueued with [queue] and will be sent via the provided
+ * [sender] function whenever a connection to the phone is available.
+ * Packets remain pending until [ack] is invoked with their sequence id.
+ */
+class OpusPacketQueue(private val sender: (Int, ByteArray) -> Unit) {
+    private val pending = linkedMapOf<Int, ByteArray>()
+    private var nextSeq = 0
+    private var connected = false
+
+    /** Queue a packet for transmission. */
+    fun queue(packet: ByteArray) {
+        val seq = nextSeq++
+        pending[seq] = packet
+        if (connected) {
+            sender(seq, packet)
+        }
+    }
+
+    /** Mark a packet as acknowledged by the phone. */
+    fun ack(seq: Int) {
+        pending.remove(seq)
+    }
+
+    /** Update connection status; flushing any pending packets when connected. */
+    fun setConnected(value: Boolean) {
+        connected = value
+        if (connected) {
+            flush()
+        }
+    }
+
+    /** Re-sends all packets that have not been acknowledged. */
+    fun flush() {
+        if (!connected) return
+        for ((seq, data) in pending) {
+            sender(seq, data)
+        }
+    }
+
+    /** Number of packets still waiting for acknowledgement. */
+    fun size(): Int = pending.size
+
+    /** Snapshot of all pending packet payloads. */
+    fun pendingPackets(): List<ByteArray> = pending.values.toList()
+}

--- a/app-wear/src/test/java/com/example/service/OpusPacketQueueTest.kt
+++ b/app-wear/src/test/java/com/example/service/OpusPacketQueueTest.kt
@@ -1,0 +1,44 @@
+package com.example.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OpusPacketQueueTest {
+    @Test
+    fun buffersUntilConnected() {
+        val sent = mutableListOf<Pair<Int, ByteArray>>()
+        val queue = OpusPacketQueue { seq, data -> sent += seq to data }
+
+        queue.queue(byteArrayOf(1))
+        queue.queue(byteArrayOf(2))
+        assertEquals(0, sent.size)
+        assertEquals(2, queue.size())
+
+        queue.setConnected(true)
+        assertEquals(2, sent.size)
+        // Packets remain until acknowledged
+        assertEquals(2, queue.size())
+    }
+
+    @Test
+    fun resendsAfterReconnectAndAckClears() {
+        val sent = mutableListOf<Int>()
+        val queue = OpusPacketQueue { seq, _ -> sent += seq }
+
+        queue.setConnected(true)
+        queue.queue(byteArrayOf(1))
+        queue.queue(byteArrayOf(2))
+        assertEquals(listOf(0, 1), sent)
+
+        sent.clear()
+        queue.setConnected(false)
+        queue.setConnected(true)
+        assertEquals(listOf(0, 1), sent)
+
+        queue.ack(0)
+        sent.clear()
+        queue.setConnected(false)
+        queue.setConnected(true)
+        assertEquals(listOf(1), sent)
+    }
+}


### PR DESCRIPTION
## Summary
- buffer outgoing Opus packets on the watch and resend when the phone reconnects
- acknowledge audio packet receipt on the phone to prevent drops
- add tests for packet buffering, reconnection and acknowledgements

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae45e3583c832a8774de15afa52763