### PR TITLE
Add Gradle build script for mobile module

### DIFF
--- a/app-mobile/build.gradle.kts
+++ b/app-mobile/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.transcriber.mobile"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.transcriber.mobile"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    sourceSets {
+        getByName("main") {
+            java.srcDir("src/main/kotlin")
+        }
+        getByName("test") {
+            java.srcDir("src/test/kotlin")
+        }
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.google.mlkit:common:18.10.0")
+    implementation("com.google.android.gms:play-services-wearable:18.0.0")
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
## Summary
- add dedicated Gradle Kotlin DSL build script for the mobile app module
- configure Android plugin, repositories, ML Kit and Wearable dependencies, source sets, and JUnit tests

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f13c09c832a8dea8144005fad71