### PR TITLE
Add microphone permission to Android manifests

### DIFF
--- a/app-mobile/src/main/AndroidManifest.xml
+++ b/app-mobile/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application>
         <service

--- a/app-wear/src/main/AndroidManifest.xml
+++ b/app-wear/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application>
         <service


### PR DESCRIPTION
## Summary
- allow recording audio on mobile and wear modules by declaring RECORD_AUDIO permission

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af31ae6974832a83e4c24b8fe6d8fc