### PR TITLE
Make AsrSession Closeable for automatic cleanup

### DIFF
--- a/app-mobile/src/main/java/com/example/postprocess/PostProcessWorker.kt
+++ b/app-mobile/src/main/java/com/example/postprocess/PostProcessWorker.kt
@@ -45,8 +45,7 @@ class PostProcessWorker(
 
     private suspend fun runHeavyAsr(audio: ByteArray): String =
         withContext(Dispatchers.Default) {
-            val session = AsrSession()
-            try {
+            AsrSession().use { session ->
                 session.pushPcm(audio)
                 val builder = StringBuilder()
                 while (true) {
@@ -55,8 +54,6 @@ class PostProcessWorker(
                     builder.append(segment)
                 }
                 if (builder.isNotEmpty()) builder.toString() else session.getPartial().orEmpty()
-            } finally {
-                session.close()
             }
         }
 

--- a/app/src/main/java/com/example/listeners/WearMessageListener.kt
+++ b/app/src/main/java/com/example/listeners/WearMessageListener.kt
@@ -32,9 +32,11 @@ class WearMessageListener(
 
     /** Stops the current recording session. */
     fun stopRecording() {
-        session?.consumeFinal()?.let {
-            captions.onFinal(it)
-            scope.launch { repository.insertSegment(TranscriptSegment(text = it)) }
+        session?.use { s ->
+            s.consumeFinal()?.let {
+                captions.onFinal(it)
+                scope.launch { repository.insertSegment(TranscriptSegment(text = it)) }
+            }
         }
         session = null
     }

--- a/app/src/main/java/com/example/session/AsrSession.kt
+++ b/app/src/main/java/com/example/session/AsrSession.kt
@@ -1,10 +1,12 @@
 package com.example.session
 
+import java.io.Closeable
+
 /**
  * Thin wrapper around the native ASR engine. Raw PCM audio is pushed into the
  * engine and partial/final transcripts are retrieved via JNI bindings.
  */
-class AsrSession {
+class AsrSession : Closeable {
     companion object {
         init {
             System.loadLibrary("asr")
@@ -25,16 +27,11 @@ class AsrSession {
     fun consumeFinal(): String? = nativeFinal(handle)
 
     /** Releases the native resources backing this session. */
-    fun close() {
+    override fun close() {
         if (handle != 0L) {
             nativeClose(handle)
             handle = 0L
         }
-    }
-
-    @Suppress("deprecation")
-    protected fun finalize() {
-        close()
     }
 
     private external fun nativeCreate(): Long


### PR DESCRIPTION
## Summary
- remove deprecated `finalize` method from `AsrSession`
- implement `Closeable` and override `close`
- apply Kotlin `use` to automatically close sessions in worker and listener

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af36983144832a9480f63d2bef8a79