### PR TITLE
docs: update README with build instructions and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,43 @@ A "phone-in-pocket, watch-on-wrist" live translator. The Wear OS watch captures 
 - Partial transcripts can drive live captions; final segments are saved along with translation.
 - A WorkManager job can re-run segments with a larger model for better accuracy.
 
-## Status
+## Components
 
-The repository currently contains scaffolding for the wearable service, the phone listener, and a translation helper. Buffering, full ASR integration, Room storage, and the post-processing worker still need implementation.
+- **Jitter buffer** smooths incoming audio before recognition.
+- **Room entities** like `TranscriptSegment` persist transcripts.
+- **Post-process worker** revisits audio with a heavier ASR model.
+- **ML Kit Language ID** detects the spoken language prior to translation.
 
 ## Development
 
 This repository uses Gradle with a centralized version catalog at `gradle/libs.versions.toml`. Dependencies and plugin versions are referenced through the `libs` catalog in the build scripts.
+
+Install the phone and watch apps on paired devices:
+
+```
+./gradlew :app-mobile:installDebug :app-wear:installDebug
+```
+
+To pair a Wear OS emulator, use:
+
+```
+adb pair <emulator-ip>:<port>
+adb connect <emulator-ip>:<port>
+```
 
 Run tests with:
 
 ```
 ./gradlew test
 ```
+
+### Versions
+
+Key versions from `gradle/libs.versions.toml`:
+
+- Android Gradle Plugin 8.12.1
+- Kotlin 2.0.21
+- Compose BOM 2024.02.00 (compiler 1.5.10)
+- Room 2.6.1 and WorkManager 2.9.0
+- ML Kit language-id 17.0.4
 


### PR DESCRIPTION
## Summary
- document jitter buffer, Room entities, post-process worker, and ML Kit language ID
- add build/install commands, Wear pairing steps, and version catalog details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad733204832aa37d97b9e6ab1431