### PR TITLE
Add Android CI workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,45 @@
+name: Android CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run checks
+        run: ./gradlew lint ktlintCheck test :app-mobile:assembleDebug :app-wear:assembleDebug
+
+      - name: Upload phone debug APK
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-mobile-debug-apk
+          path: app-mobile/build/outputs/apk/debug/*.apk
+
+      - name: Upload wear debug APK
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-wear-debug-apk
+          path: app-wear/build/outputs/apk/debug/*.apk
+
+      - name: Publish Android Lint SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: '**/lint-results-*.sarif'


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test Android apps

## Testing
- `./gradlew lint ktlintCheck test :app-mobile:assembleDebug :app-wear:assembleDebug` (fails: Task 'ktlintCheck' not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0af00afcc832a88e5bfbe50e0aac5