### PR TITLE
Add security, contribution, and license guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+We are committed to fostering an open and welcoming environment.
+
+## Our Pledge
+Participants agree to treat everyone with respect and courtesy.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+
+Unacceptable behavior includes harassment, insults, and unwelcome sexual attention.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or emailing security@transcriberapp.org. All complaints will be reviewed and investigated.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thanks for your interest in contributing to this project!
+
+## Getting Started
+- Fork the repository and create your branch from `main`.
+- Ensure any install or build dependencies are removed before the end of the layer when doing a build.
+- Run `./gradlew test` to make sure tests pass.
+
+## Pull Requests
+- Describe your changes and include relevant issue numbers.
+- Update documentation as appropriate.
+- Make sure your code passes tests and lints.
+
+By contributing, you agree that your contributions will be licensed under the terms of the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+We take security seriously and appreciate your efforts to responsibly disclose vulnerabilities.
+
+## Reporting a Vulnerability
+
+If you discover a security issue in this project, please report it as soon as possible:
+
+- Open a [GitHub issue](../../issues) with details.
+- For sensitive reports, email us at security@transcriberapp.org.
+
+Please provide a description of the issue and steps to reproduce. We will respond as quickly as possible.


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- document how to report security issues in `SECURITY.md`
- add `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a79f194832ab97a4c984abdfd38