### PR TITLE
chore: ignore app-wear bin outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 .gradle/
+
+# Gradle and IDE build outputs
 build/
 */build/
+
+# Prevent committing generated binaries
 bin/
 */bin/
+app-wear/bin/
+
 .kotlin/
 /codex
 local.properties


### PR DESCRIPTION
## Summary
- ignore the `app-wear/bin` directory and other binary outputs

## Testing
- `git check-ignore -v app-wear/bin/tempfile`
- `./gradlew :app-wear:assembleDebug` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b10bacedb8832aadf22da40e83e2ef